### PR TITLE
Scale ECharts node size using level

### DIFF
--- a/graph.html
+++ b/graph.html
@@ -127,14 +127,21 @@
       var forest = roots.map(dfs);
 
       // Build graph nodes + links
+      var sizeFactor = 8; // enlarge nodes based on level (1-7 -> 8-56)
       var nodes = Array.from(nodesSet).map(function (id) {
         var lvl = levelByNode.has(id) ? levelByNode.get(id) : null;
-        return {
+        var node = {
           id: id,                // URI (used internally for linking)
           name: label(id),       // visible label on the node
           value: id,             // keep URI here for tooltip access
           // category left undefined on purpose (levels aren't very useful visually)
         };
+        if (lvl != null) {
+          var scaled = lvl * sizeFactor;
+          node.size = scaled;
+          node.symbolSize = scaled;
+        }
+        return node;
       });
 
       // Fast lookup for link augmentation


### PR DESCRIPTION
## Summary
- derive node size from `level` and apply a constant multiplier for visibility

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('echarts_graph.json','utf8')); console.log('json ok');"`
- `node -e "require('fs').readFileSync('graph.html'); console.log('graph read');"`


------
https://chatgpt.com/codex/tasks/task_e_68a4800a3fbc8327bff5007aa0b99939