### PR TITLE
Fix edge array detection in graph loader

### DIFF
--- a/graph.html
+++ b/graph.html
@@ -205,9 +205,9 @@
         myChart.hideLoading();
 
         // Detect edges-only JSON and transform if needed
-        var looksLikeEdgesArray = Array.isArray(graph) && graph.length > 0
-          && graph[0] && typeof graph[0] === 'object'
-          && ('pathwayNodeUri' in graph[0]) && ('parentNodeUri' in graph[0]);
+        var looksLikeEdgesArray = Array.isArray(graph) && graph.some(function (row) {
+          return row && typeof row === 'object' && ('pathwayNodeUri' in row) && ('parentNodeUri' in row);
+        });
 
         var edges = null;
         var labelsByUri = (graph && (graph.labelsByUri || graph.labels)) || {};


### PR DESCRIPTION
## Summary
- Detect edge arrays by scanning all rows for `pathwayNodeUri` and `parentNodeUri`
- Restore graph rendering when datasets include preliminary rows without these keys

## Testing
- `python - <<'PY'
from playwright.sync_api import sync_playwright
with sync_playwright() as p:
    browser=p.chromium.launch()
    page=browser.new_page()
    page.goto('http://localhost:8000/graph.html')
    page.wait_for_timeout(5000)
    option=page.evaluate('myChart.getOption()')
    print('series length', len(option['series'][0]['data']))
    print('link length', len(option['series'][0]['links']))
    browser.close()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a4a12833248327aa209da2adc9ff6a