### PR TITLE
Allow typing custom protein URIs

### DIFF
--- a/graph.html
+++ b/graph.html
@@ -46,7 +46,8 @@
   <div class="bg-gray-100 p-4 flex flex-col space-y-2">
     <div class="flex items-center space-x-2">
       <label for="protein-uri" class="font-medium">Protein URI</label>
-      <select id="protein-uri" class="border rounded p-2 flex-1 w-[100ch]"></select>
+      <input id="protein-uri" list="protein-uri-list" placeholder="Select a protein" class="border rounded p-2 flex-1 w-[100ch]" />
+      <datalist id="protein-uri-list"></datalist>
       <button id="go-button" class="bg-blue-500 text-white px-4 py-2 rounded">Go</button>
       <div id="status" class="ml-auto text-sm text-gray-600">select a protein</div>
     </div>
@@ -92,16 +93,11 @@
       'protein/1937e1bb-7ba7-34e1-a578-cd216679772c',
       'protein/446a1cd5-a7b3-31d9-80ec-07c641ce232c'
     ];
-    var selectEl = document.getElementById('protein-uri');
-    var placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.textContent = 'Select a protein';
-    selectEl.appendChild(placeholder);
+    var listEl = document.getElementById('protein-uri-list');
     proteinUris.forEach(function (uri) {
       var opt = document.createElement('option');
       opt.value = uri;
-      opt.textContent = uri;
-      selectEl.appendChild(opt);
+      listEl.appendChild(opt);
     });
 
     // --- Edge list -> ECharts converter (uses edge.label for node labels) ---

--- a/tests/graph.spec.js
+++ b/tests/graph.spec.js
@@ -38,7 +38,7 @@ test.afterAll(() => {
 test('graph has categories, pathway node, info panel updates, thin edges', async ({ page }) => {
   const base = `http://localhost:${server.address().port}`;
   await page.goto(base + '/graph.html');
-  await page.selectOption('#protein-uri', { value: 'protein/b22c31bd-9452-3c21-8dba-ce524c489003' });
+  await page.fill('#protein-uri', 'protein/b22c31bd-9452-3c21-8dba-ce524c489003');
   await page.click('#go-button');
   await page.waitForFunction(() => document.getElementById('status').textContent.startsWith('ready'));
 


### PR DESCRIPTION
## Summary
- Allow entering a protein URI directly or selecting from suggestions via a text input with datalist
- Update Playwright test to fill the input instead of selecting an option

## Testing
- `npx playwright test` *(fails: Host system is missing dependencies to run browsers)*


------
https://chatgpt.com/codex/tasks/task_e_68a55d6fa414832791de98b2e89627b6